### PR TITLE
AWS Lambdaにアップロードするzipファイル作成をシェルスクリプト化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# credentials for development
+.secrets

--- a/amazon_env/Dockerfile
+++ b/amazon_env/Dockerfile
@@ -1,5 +1,9 @@
-FROM amazonlinux:latest
+FROM amazonlinux:2.0.20191217.0
 
 RUN yum update -y \
-    && yum install python3 zip -y \
-    && pip3 install virtualenv
+    && yum install python3 zip -y
+
+COPY entrypoint.sh /usr/local/bin/
+WORKDIR /var/task
+
+ENTRYPOINT [ "entrypoint.sh" ]

--- a/amazon_env/entrypoint.sh
+++ b/amazon_env/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eu
+BUNDLE_ZIP_FILE=/var/task/bundle.zip
+
+python3 -m pip install -t . -r requirements.txt
+zip -r9 $BUNDLE_ZIP_FILE *
+zip -gr9 $BUNDLE_ZIP_FILE .[^.]*

--- a/create_deploy_zip.sh
+++ b/create_deploy_zip.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eu
+
+DOCKER_IMAGE_FOR_BUILD=aws-lambda-python37
+DOCKER_IMAGE_VERSION=1.1
+DOCKER_IMAGE=$DOCKER_IMAGE_FOR_BUILD:$DOCKER_IMAGE_VERSION
+
+BUILD_DIR=build
+
+rm -rf $BUILD_DIR
+mkdir $BUILD_DIR
+cp main.py $BUILD_DIR/
+cp amazon_env/* $BUILD_DIR/
+cp $CREDENTIALS_PATH $BUILD_DIR/
+
+cd $BUILD_DIR
+docker build -t $DOCKER_IMAGE .
+docker run --rm -v $PWD:/var/task $DOCKER_IMAGE


### PR DESCRIPTION
推しのデプロイプロセスの手短なカイゼンとしてシェルスクリプトを作成した
ref: https://github.com/ftnext/emily-minder-bot/issues/1

```shell
$ CREDENTIALS_PATH=/awesome/path ./create_deploy_zip.sh
...
# build/bundle.zip をLambdaにアップロードすればよい
```

必要なスクリプトやクレデンシャルのファイル、外部パッケージをzipにまとめている

- create_deploy_zip.shで必要なものをzip作成用のディレクトリに移動
- amazonlinuxのDockerイメージを起動し、プラットフォームを揃えた上でパッケージをインストールし、フォルダ内をzip化する